### PR TITLE
only duplicate logs that are coming from ProgressLogging

### DIFF
--- a/src/compute_plr.jl
+++ b/src/compute_plr.jl
@@ -162,6 +162,7 @@ point. Uses all available threads if not provided.
 """
 function simulate!(s::PLR_Simulation; logger = progress_logger(), ntasks::Union{Nothing,Int} = nothing)
     with_logger(logger) do
+        Threads.nthreads() == 1 && @warn("Your running julia session is only using one thread, consider starting julia with multiple threads to speed up the computation")
         ProgressLogging.@progress name = "PLR Simulation" for i in eachindex(s.results)
             simpoint = s.results[i]
             # If this point already has a valid result, we skip it

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -36,7 +36,11 @@ end
 
 # The default set of loggers passed for the progress_channesl, including both the default one and a custom TerminalLogger to also show progress outside of the VSCode progress bar.
 progress_logger() = if isinteractive()
-    TeeLogger(current_logger(), terminal_logger())
+    # We only copy to the terminal logger the loggings from ProgresLogging.jl, which have a LogLevel of -1
+    filtered_terminal = EarlyFilteredLogger(terminal_logger()) do log
+        log.level == LogLevel(-1)
+    end
+    TeeLogger(current_logger(), filtered_terminal)
 else
     current_logger()
 end


### PR DESCRIPTION
As per title and add a warning when running simulations with a single core