### PR TITLE
Add more advanced MF-CRDSA scheme

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -24,7 +24,7 @@ PlotlyBase = "a03496cd-edff-5a9b-9e67-9cda94a718b5"
 PlotlyBaseExt = ["PlotlyBase"]
 
 [compat]
-Bumper = "0.6"
+Bumper = "0.6, 0.7"
 ChunkSplitters = "2"
 Distributions = "0.25"
 DocStringExtensions = "0.9"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SlottedRandomAccess"
 uuid = "3cd48f03-9865-4243-ab2c-9fbbaa30d0d4"
 authors = ["Alberto Mengali <disberd@gmail.com>"]
-version = "0.1.1"
+version = "0.2.0-DEV"
 
 [deps]
 Bumper = "8ce10254-0962-460f-a3d8-1f77fea1446e"

--- a/src/interface_functions.jl
+++ b/src/interface_functions.jl
@@ -36,11 +36,14 @@ function replicas_positions(::CRDSA{N}, nslots) where N
 	end
 end
 # MF-CRDSA version, creates N random slots, each falling into the respective partition of `nslots` into `N` non-overlapping groups
-function replicas_positions(::MF_CRDSA{N}, nslots) where N
-	@assert mod(nslots, N) == 0 "The number of total slots must be a multiple of the number of replicas"
-	offset = nslots ÷ N
+function replicas_positions(scheme::MF_CRDSA{N}, nslots) where N
+    (;n_time_slots) = scheme # This is the number of assumed time slots in the frame
+	@assert mod(nslots, n_time_slots) == 0 "The number of total slots must be a multiple of the number of replicas"
+	offset = nslots ÷ n_time_slots
+    # We enforce the return type so that we get an error if the provided generation function gives the wrong one
+    tslots = scheme.time_slots_function()::NTuple{N, Int}
 	return ntuple(Val{N}()) do i
-		rand(1:offset) + (i-1) * offset
+		rand(1:offset) + (tslots[i]-1) * offset
 	end
 end
 

--- a/src/interface_functions.jl
+++ b/src/interface_functions.jl
@@ -38,7 +38,7 @@ end
 # MF-CRDSA version, creates N random slots, each falling into the respective partition of `nslots` into `N` non-overlapping groups
 function replicas_positions(scheme::MF_CRDSA{N}, nslots) where N
     (;n_time_slots) = scheme # This is the number of assumed time slots in the frame
-	@assert mod(nslots, n_time_slots) == 0 "The number of total slots must be a multiple of the number of replicas"
+	@assert mod(nslots, n_time_slots) == 0 "The number of total slots must be a multiple of the number of time slots."
 	offset = nslots ÷ n_time_slots
     # We enforce the return type so that we get an error if the provided generation function gives the wrong one
     tslots = scheme.time_slots_function()::NTuple{N, Int}

--- a/src/types.jl
+++ b/src/types.jl
@@ -76,7 +76,10 @@ struct MF_CRDSA{N, F} <: FixedRepSlottedRAScheme{N}
     "This function is used to generate the time slots (between 1 and `time_slots`). It should be a function (or callable) that takes no argument and return an `NTuple{N, Int}` with the time slots of each replica (without repetitions)."
     time_slots_function::F
     # Inner constructor
-    MF_CRDSA{N}(time_slots::Int, time_slots_function::F) where {N, F} = new{N, F}(time_slots, time_slots_function)
+    function MF_CRDSA{N}(time_slots::Int, time_slots_function::F) where {N, F} 
+        N <= time_slots || throw(ArgumentError("The number of replicas ($N) cannot be greater than the number of time slots ($time_slots)"))
+        new{N, F}(time_slots, time_slots_function)
+    end
 end
 MF_CRDSA{N}() where N = MF_CRDSA{N}(N, EachTimeSlot{N}())
 

--- a/src/types.jl
+++ b/src/types.jl
@@ -28,14 +28,57 @@ See also: [`MF_CRDSA`](@ref)
 struct CRDSA{N} <: FixedRepSlottedRAScheme{N} end
 
 """
+    This strcut, when called, will simply return the tuple of Int numbers from `1` to `N`. It is used as the default _Callable_ when initializing the [`MF_CRDSA`](@ref) struct with no arguments
+"""
+struct EachTimeSlot{N} end
+(::EachTimeSlot{N})() where N = ntuple(identity, Val{N}())
+
+"""
 $TYPEDEF
 Type representing the _Multi-Frequency Contention Resolution Diversity Slotted ALOHA_ (MF-CRDSA) scheme, with a number of replicas `N`.
 
 This RA scheme was introduced in [this 2017 IEEE paper](https://doi.org/10.1109/TCOMM.2017.2696952).
 
+The scheme can support a number of time slots that is different than the number of replicas, though the originating paper only implements a scheme where one replica (and only one) is sent in each time slot.
+
+!!! note
+    When specifying the number of frame slots in the [`PLR_SimulationParameters`](@ref), the total number of slots in the frame (`nslots`) is assumed to be the product of time slots and frequency slots.
+
+    So for example when putting `nslots = 100` in the [`PLR_SimulationParameters`](@ref) and using a MF-CRDSA scheme with `time_slots = 2`, the number of frequency slots is assumed to be `50`.
+
+The assumed number of time slots and the function used to generate them randomly can be modified through the structure fields listed below.
+
+# Fields
+$TYPEDFIELDS
+
+!!! note
+    The current implementation still assumes that there is only a single replica per time slot, so while the `time_slots_function` is arbitrary, potentially wrong results will be returned if this is not the case.
+
+# Constructors
+    MF_CRDSA{N}()
+
+Default construct, which assumes `N` time slots (so one per replica) and that one replica is sent in each time slot (randomizing over the frequency slots).
+
+    MF_CRDSA{N}(n_time_slots::Int, time_slots_function)
+More advanced constructor for the MF-CRDSA scheme, which allows specifying a number of time slots different than the number of replicas and the function to be used to generate randomly the time slots to use for each user in each frame.
+
+## Example
+The code below will generate a MF-CRDSA scheme with 2 replicas and 3 time slots, where the first time slot is always used for the first replica, while the second replica is sent randomly either in the 2nd or 3rd slot.
+```julia-repl
+julia> scheme = MF_CRDSA{2}(3, () -> (1, rand(2:3)))
+```
+
 See also: [`CRDSA`](@ref)
 """
-struct MF_CRDSA{N} <: FixedRepSlottedRAScheme{N} end
+struct MF_CRDSA{N, F} <: FixedRepSlottedRAScheme{N} 
+    "The number of time slots in each RA frame for this MF-CRDSA scheme, must be a number equal or greater than the number of replicas `N`"
+    n_time_slots::Int
+    "This function is used to generate the time slots (between 1 and `time_slots`). It should be a function (or callable) that takes no argument and return an `NTuple{N, Int}` with the time slots of each replica (without repetitions)."
+    time_slots_function::F
+    # Inner constructor
+    MF_CRDSA{N}(time_slots::Int, time_slots_function::F) where {N, F} = new{N, F}(time_slots, time_slots_function)
+end
+MF_CRDSA{N}() where N = MF_CRDSA{N}(N, EachTimeSlot{N}())
 
 """
     @enum ReplicaPowerStrategy SamePower IndependentPower

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -19,4 +19,6 @@
     @test all(x -> x[1] == 1, test_vec)
     second_time_slots = unique(map(x -> x[2], test_vec))
     @test sort(second_time_slots) == [2,3]
+
+    @test_throws "cannot be greater than the number of time slots" MF_CRDSA{4}(3, () -> (1,2,3,4))
 end

--- a/test/basics.jl
+++ b/test/basics.jl
@@ -1,0 +1,22 @@
+@testitem "Basics" begin
+    using SlottedRandomAccess
+    using SlottedRandomAccess: replicas_positions
+    using Test
+
+    scheme = MF_CRDSA{3}()
+
+    @test_throws "a multiple of the number of time slots" replicas_positions(scheme, 100)
+
+    test_vec = map(_ -> replicas_positions(scheme, 99), 1:10)
+    @test all(test_vec) do (s1, s2, s3)
+        s1 <= 33 &&
+        33 < s2 <= 66 &&
+        66 < s3 <= 99
+    end
+
+    scheme = MF_CRDSA{2}(3, () -> (1, rand(2:3)))
+    test_vec = map((x) -> scheme.time_slots_function(), 1:10)
+    @test all(x -> x[1] == 1, test_vec)
+    second_time_slots = unique(map(x -> x[2], test_vec))
+    @test sort(second_time_slots) == [2,3]
+end

--- a/test/readme_example.jl
+++ b/test/readme_example.jl
@@ -1,0 +1,64 @@
+@testitem "Reduced Readme Example" begin
+    using SlottedRandomAccess
+    using PlotlyBase # This is not part of the package env
+    # Generic parameters
+    common = (; M=4, coderate=1 / 3, power_strategy=SamePower)
+    coding_gain = common.coderate * log2(common.M) |> x -> -10log10(x)
+    line_colors = [ # Use to match the line colors
+        "rgb(93, 146, 191)", # 6dB, blue
+        "rgb(233, 71, 72)", # 9dB, red
+        "rgb(113, 191, 109)", # 12dB, green
+    ]
+    ebno_max_vec = [6, 9, 12]
+    # Define the load vector
+    load = 0.1:0.1:.2
+    # Create the CRDSA curves
+    crdsa_sims = map(1:3) do idx
+        ebno_max = ebno_max_vec[idx]
+        line_color = line_colors[idx]
+        # Define the RA scheme to use
+        scheme = CRDSA{3}()
+        # Define the power distribution for the replicas
+        power_dist = LogUniform_dB(2 - coding_gain, ebno_max - coding_gain)
+        # Create the simulation object
+        sim = PLR_Simulation(load;
+            common...,
+            power_dist,
+            scheme,
+            nslots=100,
+        )
+        add_scatter_kwargs!(sim;
+            name="N<sub>rep</sub> = 3, [E<sub>b</sub>N<sub>0</sub>]<sub>max</sub> = $(ebno_max)dB",
+            line_color,
+            line_dash=:solid,
+            marker_symbol=:square,
+        )
+        simulate!(sim) # Compute the packet loss ratio
+    end
+    # Create the MF-CRDSA curves
+    mf_crdsa_sims = map(1:3) do idx
+        ebno_max = ebno_max_vec[idx]
+        line_color = line_colors[idx]
+        # Define the RA scheme to use
+        scheme = MF_CRDSA{3}()
+        # Define the power distribution for the replicas
+        power_dist = LogUniform_dB(2 - coding_gain, ebno_max - coding_gain)
+        # Create the simulation object
+        sim = PLR_Simulation(load;
+            common...,
+            power_dist,
+            scheme,
+            nslots=99,
+        )
+        # Add information to customize the plot to the simulation object
+        add_scatter_kwargs!(sim;
+            name="MF, N<sub>rep</sub> = 3, [E<sub>b</sub>N<sub>0</sub>]<sub>max</sub> = $(ebno_max)dB",
+            line_color,
+            line_dash=:dash,
+            marker_symbol=:diamond
+        )
+        simulate!(sim) # Compute the packet loss ratio
+    end
+    # Plot the MF-CRDSA and CRDSA curves together
+    Plot(vcat(crdsa_sims, mf_crdsa_sims))
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,69 +20,7 @@ end
     report_package("SlottedRandomAccess")
 end
 
-@testitem "Reduced Readme Example" begin
-    using SlottedRandomAccess
-    using PlotlyBase # This is not part of the package env
-    # Generic parameters
-    common = (; M=4, coderate=1 / 3, power_strategy=SamePower)
-    coding_gain = common.coderate * log2(common.M) |> x -> -10log10(x)
-    line_colors = [ # Use to match the line colors
-        "rgb(93, 146, 191)", # 6dB, blue
-        "rgb(233, 71, 72)", # 9dB, red
-        "rgb(113, 191, 109)", # 12dB, green
-    ]
-    ebno_max_vec = [6, 9, 12]
-    # Define the load vector
-    load = 0.1:0.1:.2
-    # Create the CRDSA curves
-    crdsa_sims = map(1:3) do idx
-        ebno_max = ebno_max_vec[idx]
-        line_color = line_colors[idx]
-        # Define the RA scheme to use
-        scheme = CRDSA{3}()
-        # Define the power distribution for the replicas
-        power_dist = LogUniform_dB(2 - coding_gain, ebno_max - coding_gain)
-        # Create the simulation object
-        sim = PLR_Simulation(load;
-            common...,
-            power_dist,
-            scheme,
-            nslots=100,
-        )
-        add_scatter_kwargs!(sim;
-            name="N<sub>rep</sub> = 3, [E<sub>b</sub>N<sub>0</sub>]<sub>max</sub> = $(ebno_max)dB",
-            line_color,
-            line_dash=:solid,
-            marker_symbol=:square,
-        )
-        simulate!(sim) # Compute the packet loss ratio
-    end
-    # Create the MF-CRDSA curves
-    mf_crdsa_sims = map(1:3) do idx
-        ebno_max = ebno_max_vec[idx]
-        line_color = line_colors[idx]
-        # Define the RA scheme to use
-        scheme = MF_CRDSA{3}()
-        # Define the power distribution for the replicas
-        power_dist = LogUniform_dB(2 - coding_gain, ebno_max - coding_gain)
-        # Create the simulation object
-        sim = PLR_Simulation(load;
-            common...,
-            power_dist,
-            scheme,
-            nslots=99,
-        )
-        # Add information to customize the plot to the simulation object
-        add_scatter_kwargs!(sim;
-            name="MF, N<sub>rep</sub> = 3, [E<sub>b</sub>N<sub>0</sub>]<sub>max</sub> = $(ebno_max)dB",
-            line_color,
-            line_dash=:dash,
-            marker_symbol=:diamond
-        )
-        simulate!(sim) # Compute the packet loss ratio
-    end
-    # Plot the MF-CRDSA and CRDSA curves together
-    Plot(vcat(crdsa_sims, mf_crdsa_sims))
-end
+include("basics.jl")
+include("readme_example.jl")
 
 @run_package_tests verbose=true


### PR DESCRIPTION
This PR allows to customize the number of time slots in the MF-CRDSA scheme to be different from the number of replicas.

This can now be achieved by calling the `MF_CRDSA{N}` constructor with 2 input arguments, representing the number of time slots and the function to generate the Tuple of time slots randomly at each frame and for each user.

This PR also added some tests, updated the Bumper compat and improved the docstring for MF-CRDSA