### PR TITLE
skip frames with 0 users

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SlottedRandomAccess"
 uuid = "3cd48f03-9865-4243-ab2c-9fbbaa30d0d4"
 authors = ["Alberto Mengali <disberd@gmail.com>"]
-version = "0.2.0"
+version = "0.2.1-DEV"
 
 [deps]
 Bumper = "8ce10254-0962-460f-a3d8-1f77fea1446e"
@@ -24,7 +24,7 @@ PlotlyBase = "a03496cd-edff-5a9b-9e67-9cda94a718b5"
 PlotlyBaseExt = ["PlotlyBase"]
 
 [compat]
-Bumper = "0.6"
+Bumper = "0.6, 0.7"
 ChunkSplitters = "2"
 Distributions = "0.25"
 DocStringExtensions = "0.9"

--- a/src/compute_plr.jl
+++ b/src/compute_plr.jl
@@ -15,7 +15,7 @@ function compute_plr_result(params::PLR_SimulationParameters, load)
             for _ in idxs
                 # Compute the effective number of users for this frame
                 nusers = poisson ? rand(Poisson(mean_users)) : round(Int, mean_users)
-                nusers > 0 && continue
+                nusers > 0 || continue
                 ndecoded = @no_escape begin
                     # Initialize the vector of users
                     users = @alloc(UserRealization{max_replicas(scheme),typeof(scheme),typeof(power_dist)}, nusers)

--- a/src/compute_plr.jl
+++ b/src/compute_plr.jl
@@ -15,6 +15,7 @@ function compute_plr_result(params::PLR_SimulationParameters, load)
             for _ in idxs
                 # Compute the effective number of users for this frame
                 nusers = poisson ? rand(Poisson(mean_users)) : round(Int, mean_users)
+                nusers > 0 && continue
                 ndecoded = @no_escape begin
                     # Initialize the vector of users
                     users = @alloc(UserRealization{max_replicas(scheme),typeof(scheme),typeof(power_dist)}, nusers)

--- a/test/readme_example.jl
+++ b/test/readme_example.jl
@@ -1,5 +1,6 @@
 @testitem "Reduced Readme Example" begin
     using SlottedRandomAccess
+    using Test
     using PlotlyBase # This is not part of the package env
     # Generic parameters
     common = (; M=4, coderate=1 / 3, power_strategy=SamePower)
@@ -11,7 +12,7 @@
     ]
     ebno_max_vec = [6, 9, 12]
     # Define the load vector
-    load = 0.1:0.1:.2
+    load = [.6, .8, 1, 1.2]
     # Create the CRDSA curves
     crdsa_sims = map(1:3) do idx
         ebno_max = ebno_max_vec[idx]
@@ -59,6 +60,50 @@
         )
         simulate!(sim) # Compute the packet loss ratio
     end
+
+    # We test that the points computed are in the range to be similar to the paper results
+    load_idx = 1 # 0.6 load
+    @test extract_plr(crdsa_sims[1].results[load_idx]) > 1e-4 # 0.6 load
+    @test extract_plr(mf_crdsa_sims[1].results[load_idx]) > 1e-4 # 0.6 load
+    @test all(2:3) do ebno_max_idx
+        extract_plr(crdsa_sims[ebno_max_idx].results[load_idx]) < 1e-4 # 0.6 load
+    end
+    @test all(2:3) do ebno_max_idx
+        extract_plr(mf_crdsa_sims[ebno_max_idx].results[load_idx]) < 1e-4 # 0.6 load
+    end
+
+    load_idx = 2 # 0.8 load
+    for sim in (crdsa_sims[1], mf_crdsa_sims[1])
+        @test .05 < extract_plr(sim.results[load_idx]) < .1 # 0.8 load
+    end
+    @test extract_plr(crdsa_sims[2].results[load_idx]) < 1e-4 # 0.8 load
+    @test extract_plr(mf_crdsa_sims[2].results[load_idx]) > 1e-4 # 0.8 load
+
+    @test extract_plr(crdsa_sims[3].results[load_idx]) < 1e-4 # 0.8 load
+    @test extract_plr(mf_crdsa_sims[3].results[load_idx]) < 1e-4 # 0.8 load
+
+    load_idx = 3 # 1 load
+    for sim in (crdsa_sims[1], mf_crdsa_sims[1])
+        @test extract_plr(sim.results[load_idx]) > .5 # 1 load
+    end
+    for sim in (crdsa_sims[2], mf_crdsa_sims[2])
+        @test 1e-2 < extract_plr(sim.results[load_idx]) < 4e-2 # 1 load
+    end
+    for sim in (crdsa_sims[3], mf_crdsa_sims[3])
+        @test extract_plr(sim.results[load_idx]) < 1e-4 # 1 load
+    end
+
+    load_idx = 4 # 1.2 load
+    for sim in (crdsa_sims[1], mf_crdsa_sims[1])
+        @test extract_plr(sim.results[load_idx]) > .8 # 1.2 load
+    end
+    for sim in (crdsa_sims[2], mf_crdsa_sims[2])
+        @test .4 < extract_plr(sim.results[load_idx]) < .5 # 1.2 load
+    end
+    for sim in (crdsa_sims[3], mf_crdsa_sims[3])
+        @test .9e-2 < extract_plr(sim.results[load_idx]) < 1.1e-2 # 1.2 load
+    end
+
     # Plot the MF-CRDSA and CRDSA curves together
     Plot(vcat(crdsa_sims, mf_crdsa_sims))
 end


### PR DESCRIPTION
This PR mostly avoid processing frames which have 0 users (due to the Poisson distribution).

Thanks @Mason for finding this very quickly in https://github.com/MasonProtter/Bumper.jl/issues/43

Put back compat with 0.7 of Bumper.jl