### PR TITLE
Small usability improvements

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SlottedRandomAccess"
 uuid = "3cd48f03-9865-4243-ab2c-9fbbaa30d0d4"
 authors = ["Alberto Mengali <disberd@gmail.com>"]
-version = "0.2.1"
+version = "0.2.2-DEV"
 
 [deps]
 Bumper = "8ce10254-0962-460f-a3d8-1f77fea1446e"

--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ end
 
 
 # Plot the MF-CRDSA and CRDSA curves together
-Plot(vcat(crdsa_sims, mf_crdsa_sims))
+Plot(vcat(crdsa_sims, mf_crdsa_sims); xaxis_dtick = .2)
 ```
 
 Which should generate something similar to the following picture:

--- a/ext/PlotlyBaseExt.jl
+++ b/ext/PlotlyBaseExt.jl
@@ -42,8 +42,6 @@ function SlottedRandomAccess.default_layout(s::PLR_Simulation; kwargs...)
             ),
         ),
         xaxis=attr(;
-            range=[0, 2],
-            dtick=0.2,
             tickfont=attr(;
                 family="Computer Modern",
                 size=15,

--- a/src/interface_functions.jl
+++ b/src/interface_functions.jl
@@ -81,6 +81,7 @@ function replicas_slots_powers(s::SlottedRAScheme, nslots; power_dist, power_str
     effective_nreplicas = sum(!iszero, slots)
     powers = replicas_power(s, effective_nreplicas; power_dist, power_strategy)
     map(slots, powers) do slot, power
+        power = Float64(power)
         (;slot, power)
     end
 end

--- a/src/types.jl
+++ b/src/types.jl
@@ -191,7 +191,7 @@ $TYPEDFIELDS
     total_sent::Int = 0
 end
 struct PLR_Simulation_Point
-    "Normalized MAC Load at which the PLR result was computed"
+    "Normalized MAC Load (bits/s/Hz or bits/Symbol) at which the PLR result is computed"
     load::Float64
     "PLR result of the simulation"
     plr::PLR_Result

--- a/src/types.jl
+++ b/src/types.jl
@@ -160,6 +160,17 @@ $TYPEDFIELDS
     "The maximum number of frames with errors to simulate. Once a simulation reaches this number of frames with errors, the simulation will stop."
     max_errored_frames::Int = 10^4
 end
+# We do a default positional constructor which promote types
+function PLR_SimulationParameters(scheme, poisson::Bool, coderate::Real, M::Real, power_dist, power_strategy::ReplicaPowerStrategy, max_simulated_frames::Real, nslots::Real, plr_func, noise_variance::Real, SIC_iterations::Real, max_errored_frames::Real)
+    coderate = Float64(coderate)
+    M = Int(M)
+    max_simulated_frames = Int(max_simulated_frames)
+    nslots = Int(nslots)
+    noise_variance = Float64(noise_variance)
+    SIC_iterations = Int(SIC_iterations)
+    max_errored_frames = Int(max_errored_frames)
+    return PLR_SimulationParameters(scheme, poisson, coderate, M, power_dist, power_strategy, max_simulated_frames, nslots, plr_func, noise_variance, SIC_iterations, max_errored_frames)
+end
 
 """
 $TYPEDSIGNATURES
@@ -184,7 +195,7 @@ struct PLR_Simulation_Point
     "PLR result of the simulation"
     plr::PLR_Result
 end
-PLR_Simulation_Point(load::Float64) = PLR_Simulation_Point(load, PLR_Result())
+PLR_Simulation_Point(load::Real) = PLR_Simulation_Point(Float64(load), PLR_Result())
 
 """
 $TYPEDEF

--- a/src/types.jl
+++ b/src/types.jl
@@ -122,7 +122,8 @@ struct UserRealization{N,RA<:SlottedRAScheme{N},D}
     "A Tuple of `N` NamedTuples (where `N` is the max number of replicas of the scheme), each containing the slot idx and power of each replica."
     slots_powers::NTuple{N,@NamedTuple{slot::Int, power::Float64}}
 end
-function UserRealization(scheme::SlottedRAScheme, nslots::Int; power_dist, power_strategy=SamePower)
+function UserRealization(scheme::SlottedRAScheme, nslots::Real; power_dist, power_strategy=SamePower)
+    nslots = Int(nslots)
     slots_powers = replicas_slots_powers(scheme, nslots; power_dist, power_strategy)
     UserRealization(scheme, nslots, power_dist, power_strategy, slots_powers)
 end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,5 +1,6 @@
 [deps]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 JET = "c3a54625-cd67-489e-a8e7-0a5a0ff4e31b"
 PlotlyBase = "a03496cd-edff-5a9b-9e67-9cda94a718b5"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/readme_example.jl
+++ b/test/readme_example.jl
@@ -61,6 +61,9 @@
         simulate!(sim) # Compute the packet loss ratio
     end
 
+    # Plot the MF-CRDSA and CRDSA curves together
+    Plot(vcat(crdsa_sims, mf_crdsa_sims))
+
     # We test that the points computed are in the range to be similar to the paper results
     load_idx = 1 # 0.6 load
     @test extract_plr(crdsa_sims[1].results[load_idx]) > 9e-5 # 0.6 load
@@ -103,7 +106,4 @@
     for sim in (crdsa_sims[3], mf_crdsa_sims[3])
         @test .9e-2 < extract_plr(sim.results[load_idx]) < 1.1e-2 # 1.2 load
     end
-
-    # Plot the MF-CRDSA and CRDSA curves together
-    Plot(vcat(crdsa_sims, mf_crdsa_sims))
 end


### PR DESCRIPTION
This PR does simple improvements, namely:
- It creates some constructors to promote input types to the right field type for PLR_SimulationParameters
- It ensures that the random generated power is a Float64, allowing to provide distributions (from Distributions) that return integer (e.g. `Dirac(2)`)
- It avoids specifying a default range a dtick to the xaxis in the `default_layout` function so that it adapts to the actual simulated load
