### PR TITLE
add overhead concept

### DIFF
--- a/src/compute_plr.jl
+++ b/src/compute_plr.jl
@@ -1,8 +1,8 @@
 # This computes the PLR result for a given load using multiple threads
 function compute_plr_result(params::PLR_SimulationParameters, load)
     @nospecialize
-    (; scheme, poisson, coderate, M, max_simulated_frames, nslots, max_errored_frames, power_dist, power_strategy) = params
-    coding_gain = 1 / (coderate * log2(M))
+    (; scheme, poisson, coderate, M, max_simulated_frames, nslots, max_errored_frames, power_dist, power_strategy, overhead) = params
+    coding_gain = 1 / (coderate * log2(M) * (1 + overhead))
     mean_users = nslots * load * coding_gain
     plr = PLR_Result() # Initializ the plr result
     ## End of tracking variables
@@ -81,8 +81,8 @@ end
 
 # Block actualy performing the decoding iterations for a single frame
 function _decoding_iterations!(slots_powers, decoded, cancelled, interference_changed; params, users)
-    (; coderate, M, plr_func, SIC_iterations) = params
-    coding_gain = 1 / (coderate * log2(M))
+    (; coderate, M, plr_func, SIC_iterations, overhead) = params
+    coding_gain = 1 / (coderate * log2(M) * (1 + overhead))
     for iter in 1:SIC_iterations
         all(decoded) && break # Stop the simulation if all users are decoded
         for u in eachindex(users)

--- a/src/compute_plr.jl
+++ b/src/compute_plr.jl
@@ -2,8 +2,9 @@
 function compute_plr_result(params::PLR_SimulationParameters, load)
     @nospecialize
     (; scheme, poisson, coderate, M, max_simulated_frames, nslots, max_errored_frames, power_dist, power_strategy, overhead) = params
-    coding_gain = 1 / (coderate * log2(M) * (1 + overhead))
-    mean_users = nslots * load * coding_gain
+    coding_gain = 1 / (coderate * log2(M))
+    # The overehad increase the required number of users for the same normalized MAC load, as the overhead does not carry information
+    mean_users = nslots * load * coding_gain * (1 + overhead)
     plr = PLR_Result() # Initializ the plr result
     ## End of tracking variables
     l = ReentrantLock() # We use this to avoid race conditions in modifying the number of frames/packets
@@ -81,8 +82,8 @@ end
 
 # Block actualy performing the decoding iterations for a single frame
 function _decoding_iterations!(slots_powers, decoded, cancelled, interference_changed; params, users)
-    (; coderate, M, plr_func, SIC_iterations, overhead) = params
-    coding_gain = 1 / (coderate * log2(M) * (1 + overhead))
+    (; coderate, M, plr_func, SIC_iterations) = params
+    coding_gain = 1 / (coderate * log2(M))
     for iter in 1:SIC_iterations
         all(decoded) && break # Stop the simulation if all users are decoded
         for u in eachindex(users)
@@ -90,6 +91,12 @@ function _decoding_iterations!(slots_powers, decoded, cancelled, interference_ch
             for (; slot, power) in users[u].slots_powers
                 interference_changed[slot] || continue
                 snir_this = power / (slots_powers[slot] - power)
+                #= 
+                We do not consider the overhead when going from SNIR to EbNo because we assume that all sources of overhead can be filtered out when actually going to SNR.
+                For example, frequency guard bands will not be included in the SRRC filter so also the noise will be removed in those band.
+                Similarly for time guard bands, the increased time will reduce the effective spectral efficiency in b/s/Hz but no power will be wasted in those bands (and no noise will be sampled).
+                Lastly, for the pilots, they can be seen as additional time, so for a given power the energy of the useful symbols will not change, the transmitter will use more energy overall as it is transmitting pilots but the non-pilot symbol will have the same energy.
+                =#
                 ebno = snir_this * coding_gain
                 # Use a coin flip to check if a packet is decoded, based on the PLR for the experienced ebno
                 this_decoded = rand() >= plr_func(ebno)

--- a/src/types.jl
+++ b/src/types.jl
@@ -160,9 +160,11 @@ $TYPEDFIELDS
     SIC_iterations::Int = 15
     "The maximum number of frames with errors to simulate. Once a simulation reaches this number of frames with errors, the simulation will stop."
     max_errored_frames::Int = 10^4
+    "Overhead assumed for the framing and or guard bands/times in the simulation. It must be a positive number representing the overhead compared to an ideal case where all resources are fully used for sending data (e.g. no pilots, no roll-off, no guard bands, no guard times). An overhead value of `1.0` implies that the spectral efficiency is half of the ideal case."
+    overhead::Float64 = 0.0
 end
 # We do a default positional constructor which promote types
-function PLR_SimulationParameters(scheme, poisson::Bool, coderate::Real, M::Real, power_dist, power_strategy::ReplicaPowerStrategy, max_simulated_frames::Real, nslots::Real, plr_func, noise_variance::Real, SIC_iterations::Real, max_errored_frames::Real)
+function PLR_SimulationParameters(scheme, poisson::Bool, coderate::Real, M::Real, power_dist, power_strategy::ReplicaPowerStrategy, max_simulated_frames::Real, nslots::Real, plr_func, noise_variance::Real, SIC_iterations::Real, max_errored_frames::Real, overhead::Real)
     coderate = Float64(coderate)
     M = Int(M)
     max_simulated_frames = Int(max_simulated_frames)
@@ -170,7 +172,8 @@ function PLR_SimulationParameters(scheme, poisson::Bool, coderate::Real, M::Real
     noise_variance = Float64(noise_variance)
     SIC_iterations = Int(SIC_iterations)
     max_errored_frames = Int(max_errored_frames)
-    return PLR_SimulationParameters(scheme, poisson, coderate, M, power_dist, power_strategy, max_simulated_frames, nslots, plr_func, noise_variance, SIC_iterations, max_errored_frames)
+    overhead = Float64(overhead)
+    return PLR_SimulationParameters(scheme, poisson, coderate, M, power_dist, power_strategy, max_simulated_frames, nslots, plr_func, noise_variance, SIC_iterations, max_errored_frames, overhead)
 end
 
 """


### PR DESCRIPTION
This PR adds a parameter to the PLR_SimulationParameters to model the overhead of the waveform.

This can be either guard band in time/frequency or pilots for example.

This parameter is must be provided as a number greater than or equal to 0 (defaults to 0), and represents the amount of time/frequency that is added without actually sending information in it.

It is effectively scaling internally the number of users generated for a specific normalized MAC Load.