### PR TITLE
Add support for 4-step Random Access simualtions

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SlottedRandomAccess"
 uuid = "3cd48f03-9865-4243-ab2c-9fbbaa30d0d4"
 authors = ["Alberto Mengali <disberd@gmail.com>"]
-version = "0.2.3"
+version = "0.3.0-DEV"
 
 [deps]
 Bumper = "8ce10254-0962-460f-a3d8-1f77fea1446e"

--- a/plr_fit_notebook.jl
+++ b/plr_fit_notebook.jl
@@ -198,6 +198,20 @@ begin
 	lin2db(x) = 10log10(x)
 end
 
+# ╔═╡ 54976715-765a-4f6f-b578-6d194581ed95
+.57 * 2 |> lin2db
+
+# ╔═╡ a0239e50-984b-483b-97b4-c3c9f3a28a2f
+let
+	esno = 1/db2lin(4.8) + 1 |> inv |> lin2db
+	r = 0.43
+	M = 4
+	esno -  lin2db(r * log2(M))
+end
+
+# ╔═╡ 2072e32a-5bfb-44c5-8a3a-f29fbf316641
+lin2db(6/7)
+
 # ╔═╡ ad3cbb4b-64c7-430a-b402-bb15efa474d6
 function fit_plr(curve_data, plr_exponent = 2)
 	(; N, M, K, ebno, plr) = curve_data
@@ -1120,11 +1134,14 @@ version = "17.4.0+2"
 # ╠═ae41ef1d-2359-4fbe-b30d-1bbbed7a9ddd
 # ╟─03ead270-1ea5-42b0-8155-d4d57be24354
 # ╟─8ff930d7-c45b-4ef7-9b85-0eac907964d8
-# ╟─d7d7f556-4d3c-4795-992b-9c7be52d0a48
+# ╠═d7d7f556-4d3c-4795-992b-9c7be52d0a48
+# ╠═54976715-765a-4f6f-b578-6d194581ed95
+# ╠═a0239e50-984b-483b-97b4-c3c9f3a28a2f
 # ╟─24b3ebbf-cb52-406a-b5c4-d450c531804c
 # ╟─9752875c-2ba8-4b18-a548-fddbaa776501
 # ╠═831d7ddc-e784-47a6-9853-848c682a380d
 # ╟─4143ee93-5113-4800-86dd-ff634ef25771
+# ╠═2072e32a-5bfb-44c5-8a3a-f29fbf316641
 # ╠═4faf8ec3-d2c6-4c45-8616-890706f58e9a
 # ╠═9a347761-bd5e-4b9d-b19b-f08aed644b26
 # ╠═e428567e-2479-4150-b7f7-c0239e4eba8f

--- a/src/SlottedRandomAccess.jl
+++ b/src/SlottedRandomAccess.jl
@@ -14,7 +14,7 @@ using TerminalLoggers
 using ScopedValues
 
 # from types.jl
-export PLR_Simulation, PLR_SimulationParameters, CRDSA, MF_CRDSA, SamePower, IndependentPower, ReplicaPowerStrategy, GeneralizedLogistic
+export PLR_Simulation, PLR_SimulationParameters, CRDSA, MF_CRDSA, SamePower, IndependentPower, ReplicaPowerStrategy, GeneralizedLogistic, SlottedALOHA, RA4Step, CollisionModel
 # from utils.jl
 export LogUniform_dB, add_scatter_kwargs!
 # from extract_plr

--- a/src/interface_functions.jl
+++ b/src/interface_functions.jl
@@ -94,3 +94,6 @@ function replicas_slots_powers(s::SlottedRAScheme, nslots; power_dist, power_str
         (;slot, power)
     end
 end
+
+compute_coding_gain(params::PLR_SimulationParameters) = 1 / (params.coderate * log2(params.M))
+compute_coding_gain(sim::PLR_Simulation) = compute_coding_gain(sim.params)

--- a/src/interface_functions.jl
+++ b/src/interface_functions.jl
@@ -21,6 +21,7 @@ See also: [`replicas_power`](@ref)
 """
 function replicas_positions end
 # CRDSA version, creates N random independent slots between 1 and nslots
+replicas_positions(::SlottedALOHA, nslots) = (rand(1:nslots),)
 function replicas_positions(::CRDSA{N}, nslots) where N
 	@no_escape begin
 		a = @alloc(Int, N)
@@ -46,6 +47,14 @@ function replicas_positions(scheme::MF_CRDSA{N}, nslots) where N
 		rand(1:offset) + (tslots[i]-1) * offset
 	end
 end
+
+# This function expects a number of slots in input which is not the slots passed to the PLR_SimulationParameters contructor, but is just based on the parameters of the RA4Step function.
+function replicas_positions(scheme::RA4Step, nslots) 
+    @assert nslots == msg1_slots(scheme) "The number of slots passed to this function does not match the expected number of virtual slots for the specified scheme $(scheme)"
+    replicas_positions(SlottedALOHA(), nslots)
+end
+msg1_slots(scheme::RA4Step) = scheme.msg1_occasions * scheme.freq_slots
+msg3_slots(scheme::RA4Step) = scheme.msg3_occasions * scheme.freq_slots
 
 """
     replicas_power(::SlottedRAScheme, effective_nreplicas::Int)

--- a/src/types.jl
+++ b/src/types.jl
@@ -26,6 +26,7 @@ This RA scheme was introduced in [this 2007 IEEE paper](https://doi.org/10.1109/
 See also: [`MF_CRDSA`](@ref)
 """
 struct CRDSA{N} <: FixedRepSlottedRAScheme{N} end
+const SlottedALOHA = CRDSA{1}
 
 """
     This strcut, when called, will simply return the tuple of Int numbers from `1` to `N`. It is used as the default _Callable_ when initializing the [`MF_CRDSA`](@ref) struct with no arguments
@@ -82,6 +83,18 @@ struct MF_CRDSA{N, F} <: FixedRepSlottedRAScheme{N}
     end
 end
 MF_CRDSA{N}() where N = MF_CRDSA{N}(N, EachTimeSlot{N}())
+
+@kwdef struct RA4Step <: FixedRepSlottedRAScheme{1} 
+    "Number of time occasions (slots) in each RA frame allocated to the msg1 random access."
+    msg1_occasions::Int
+    "Number of time occasions (slots) in each RA frame allocated to the msg3 transmission."
+    msg3_occasions::Int
+    "Number of frequency slots (i.e. sub-carriers) available in each time slot, it is assumed that the number of subcarriers is the same for both msg1 and msg3 transmissions."
+    freq_slots::Int
+    "Flag to specify whether to limit the number of maximum decoded packet to the number of slots associated to msg3 transmission (which is equivalent to `msg3_occasions * freq_slots`)."
+    limit_packets::Bool
+end
+RA4Step(msg1_occasions::Number, msg3_occasions::Number; freq_slots::Number = 48, limit_packets::Bool = true) = RA4Step(Int(msg1_occasions), Int(msg3_occasions), Int(freq_slots), limit_packets)
 
 """
     @enum ReplicaPowerStrategy SamePower IndependentPower
@@ -297,3 +310,5 @@ See the `plr_fit_notebook.jl` notebook in the package root folder for example of
     M::Int
 end
 (p::PLR_Fit)(ebno) = p.plr_func(ebno)
+
+struct CollisionModel end

--- a/src/types.jl
+++ b/src/types.jl
@@ -26,6 +26,13 @@ This RA scheme was introduced in [this 2007 IEEE paper](https://doi.org/10.1109/
 See also: [`MF_CRDSA`](@ref)
 """
 struct CRDSA{N} <: FixedRepSlottedRAScheme{N} end
+"""
+    const SlottedALOHA = CRDSA{1}
+This is just an alias to represent SlottedALOHA with the CRDSA type, you create a slotted aloha scheme with the following code:
+```julia-repl
+julia> scheme = SlottedALOHA()
+```
+"""
 const SlottedALOHA = CRDSA{1}
 
 """
@@ -84,6 +91,27 @@ struct MF_CRDSA{N, F} <: FixedRepSlottedRAScheme{N}
 end
 MF_CRDSA{N}() where N = MF_CRDSA{N}(N, EachTimeSlot{N}())
 
+"""
+$TYPEDEF
+Type representing the 4-step RA procedure, where Slotted ALOHA is used during the RA contention period (msg1) and succesfully decoded msg1 packets are used to allocate orthogonal resources for the msg3 transmission of the actual data.
+
+!!! note
+    This type of RA scheme will only simulate the packet decoding process for the msg1 and optionally limit the maximum number of succesfull packets per frame to be the number of slots available for msg3 transmission.
+
+# Fields
+$TYPEDFIELDS
+
+# Constructors
+    RA4Step(msg1_occasions, msg3_occasions; freq_slots = 48, limit_packets = true)
+
+## Example
+The code below will generate a 4-step RA scheme with 5 time occasions for msg1 every 2 time occasions for msg3, while assuming 20 frequency slots (i.e. subcarriers) for each time slots and while limiting the maximum number of decoded packets in each frame to the actual number of msg3 slots (which is `2 * 20`).
+```julia-repl
+julia> scheme = RA4Step(5, 2; freq_slots = 20, limit_packets = true)
+```
+
+See also: [`CRDSA`](@ref), [`MF-CRDSA`](@ref)
+"""
 @kwdef struct RA4Step <: FixedRepSlottedRAScheme{1} 
     "Number of time occasions (slots) in each RA frame allocated to the msg1 random access."
     msg1_occasions::Int
@@ -311,4 +339,10 @@ See the `plr_fit_notebook.jl` notebook in the package root folder for example of
 end
 (p::PLR_Fit)(ebno) = p.plr_func(ebno)
 
+"""
+    CollisionModel()
+Type to be used as `plr_func` when instantiating [`PLR_SimulationParameters`](@ref) or [`PLR_Simulation`](@ref), which will mimic a collision model for the PHY abstraction.
+!!! note
+    An instance of `CollisionModel` is not callable like all other `plr_func` values, the collision model is just implemented directly inside the inner code performing the simulation.
+"""
 struct CollisionModel end

--- a/test/plot_tests.jl
+++ b/test/plot_tests.jl
@@ -1,0 +1,18 @@
+@testitem "PlotlyBase Extension tests" begin
+    using PlotlyBase
+    using SlottedRandomAccess
+    using Distributions
+    using Test
+
+    power_dist = Dirac(5)
+
+    scheme = RA4Step(10000, 2; freq_slots = 1, limit_packets = false)
+    sim_1 = PLR_Simulation([2]; scheme, power_dist, coderate=1/2, plr_func = CollisionModel(), poisson = false, max_simulated_frames = 100)
+    simulate!(sim_1)
+
+    layout_1 = Plot(sim_1; xtype = :packets).layout;
+    @test layout_1.xaxis_title_text == "Average Load (packets/slot)"
+
+    layout_2 = Plot(sim_1; xtype = :speff).layout;
+    @test layout_2.xaxis_title_text == "Average Load, G (bits/symbol)"
+end

--- a/test/plot_tests.jl
+++ b/test/plot_tests.jl
@@ -17,4 +17,5 @@
     @test layout_2.xaxis_title_text == "Average Load, G (bits/symbol)"
 
     @test_throws "`xtype`" Plot(sim_1; xtype = :asd).layout; 
+    @test_throws "`xtype`" scatter(sim_1, :asd)
 end

--- a/test/plot_tests.jl
+++ b/test/plot_tests.jl
@@ -15,4 +15,6 @@
 
     layout_2 = Plot(sim_1; xtype = :speff).layout;
     @test layout_2.xaxis_title_text == "Average Load, G (bits/symbol)"
+
+    @test_throws "`xtype`" Plot(sim_1; xtype = :asd).layout; 
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -22,5 +22,6 @@ end
 
 include("basics.jl")
 include("readme_example.jl")
+include("plot_tests.jl")
 
 @run_package_tests verbose=true


### PR DESCRIPTION
This PR add a new type `RA4Step` to simulate 4-step random access.

It also create a `CollisionModel` struct that can be used as input for the `plr_func` field of `PLR_SimulationParameters` to use a collision model for the PHY abstraction.

Lastly, it creates an alias called `SlottedALOHA` for `CRDSA{1}`.

The changes in this PR cause allocations in the generation of `UserRealization` in the plr simulation loop (not sure still why) so there is some slow down that will be hopefully fixed in a next patch version